### PR TITLE
Links to dev docs in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Building from source
 
 If you are building from source, take note that the build depends on NuGet packages hosted on Myget, so if it is down, the build may fail. If that happens, you can always see the [Myget status page](http://status.myget.org/) for more info. 
 
+Read over the [contributing guidelines](https://github.com/dotnet/cli/tree/master/CONTRIBUTING.md) and [developer documentation](https://github.com/dotnet/cli/tree/master/Documentation) for prerequisites for building from source.
+
 Questions & Comments
 --------------------
 


### PR DESCRIPTION
As a newbie to building cli from source it was easy to miss the dev documentation and jump straight into running build.cmd not realizing I needed cmake etc to be installed.
